### PR TITLE
performance: explicit sleep in Mpp::get_frame

### DIFF
--- a/mpp/mpp.cpp
+++ b/mpp/mpp.cpp
@@ -284,9 +284,10 @@ MPP_RET Mpp::get_frame(MppFrame *frame)
                 }
             } else
                 mFrames->wait();
+        } else {
+            /* NOTE: this sleep is to avoid user's dead loop */
+            msleep(1);
         }
-        /* NOTE: this sleep is to avoid user's dead loop */
-        msleep(1);
     }
 
     if (mFrames->list_size()) {


### PR DESCRIPTION
Move msleep() to non MPP_POLL_BLOCK (cv wait) branch.
Issue rockchip-linux/mpp#6