### PR TITLE
DRM: make it works

### DIFF
--- a/mpp/base/mpp_buffer_impl.cpp
+++ b/mpp/base/mpp_buffer_impl.cpp
@@ -326,7 +326,7 @@ MPP_RET mpp_buffer_mmap(MppBufferImpl *buffer, const char* caller)
         buffer_group_add_log(group, buffer, BUF_MMAP, caller);
     }
 
-    if (ret)
+    if (ret && (group->alloc_api && !group->alloc_api->mmap))
         mpp_err_f("buffer %p group %p fd %d map failed caller %s\n",
                   buffer, group, buffer->info.fd, caller);
 

--- a/mpp/base/mpp_buffer_impl.cpp
+++ b/mpp/base/mpp_buffer_impl.cpp
@@ -635,7 +635,7 @@ MppBufferGroupImpl *MppBufferService::get_group(const char *tag, const char *cal
 
 MppBufferGroupImpl *MppBufferService::get_misc_group(MppBufferMode mode, MppBufferType type)
 {
-    if (type == MPP_BUFFER_TYPE_NORMAL)
+    if (type != MPP_BUFFER_TYPE_ION)
         return NULL;
 
     mpp_assert(type == MPP_BUFFER_TYPE_ION);

--- a/osal/allocator/allocator_drm.c
+++ b/osal/allocator/allocator_drm.c
@@ -320,7 +320,7 @@ static MPP_RET os_allocator_drm_import(void *ctx, MppBufferInfo *data)
 static MPP_RET os_allocator_drm_release(void *ctx, MppBufferInfo *data)
 {
     (void)ctx;
-    munmap(data->ptr, data->size);
+    if (data->ptr) munmap(data->ptr, data->size);
     close(data->fd);
     return MPP_OK;
 }
@@ -335,7 +335,7 @@ static MPP_RET os_allocator_drm_free(void *ctx, MppBufferInfo *data)
     }
 
     p = (allocator_ctx_drm *)ctx;
-    munmap(data->ptr, data->size);
+    if (data->ptr) munmap(data->ptr, data->size);
     close(data->fd);
     drm_free(p->drm_device, (RK_U32)((intptr_t)data->hnd));
     return MPP_OK;


### PR DESCRIPTION
Hello.
The DRM buffers does not works if allocated in "mpp_buffer_commit usage" to work in "Mode 3: Pure external mode" with "Split standard mode" ("mpp_buffer_import usage"/"Advanced mode" does work only with MJPEG). See application http://tinkerboarding.co.uk/forum/showthread.php?tid=51
This patches make it works for me.
M.C>