### PR TITLE
Fix buffer overflow scanning soc_name.

### DIFF
--- a/osal/mpp_platform.cpp
+++ b/osal/mpp_platform.cpp
@@ -180,9 +180,9 @@ MppPlatformService::MppPlatformService()
                 /* replacing the termination character to space */
                 for (char *ptr = soc_name;; ptr = soc_name) {
                     ptr += strnlen (soc_name, MAX_SOC_NAME_LENGTH);
-                    *ptr = ' ';
                     if (ptr >= soc_name + soc_name_len - 1)
                         break;
+                    *ptr = ' ';
                 }
 
                 mpp_dbg(MPP_DBG_PLATFORM, "chip name: %s\n", soc_name);


### PR DESCRIPTION
The soc_name we read from device-tree is NUL-separated so we need to
replace intervening NUL chars, but we don't want to replace the last
one, or the next call to strstr() will overflow the buffer.

Detected with address-sanitizer:

    ==3271==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7f940026a0 at pc 0x7f97df7160 bp 0x7fee1fa8e0 sp 0x7fee1fa958
    READ of size 97 at 0x7f940026a0 thread T0
        #0 0x7f97df715f  (/usr/lib/libasan.so.3+0x4215f)
        #1 0x7f97df745b in __interceptor_strstr (/usr/lib/libasan.so.3+0x4245b)
        #2 0x7f97d6b27b in MppPlatformService::MppPlatformService() (/usr/lib/librockchip_mpp.so.1+0x8727b)
        #3 0x7f97d6b64f in mpp_get_vcodec_type (/usr/lib/librockchip_mpp.so.1+0x8764f)
        #4 0x7f97d38da3 in hal_h264d_init (/usr/lib/librockchip_mpp.so.1+0x54da3)

    0x7f940026a0 is located 0 bytes to the right of 96-byte region [0x7f94002640,0x7f940026a0)
    allocated by thread T0 here:
        #0 0x7f97e6445b in __interceptor_posix_memalign (/usr/lib/libasan.so.3+0xaf45b)
        #1 0x7f97d6ed13 in os_malloc (/usr/lib/librockchip_mpp.so.1+0x8ad13)
        #2 0x7f97d6e54b in mpp_osal_malloc (/usr/lib/librockchip_mpp.so.1+0x8a54b)
        #3 0x7f97d6b1d7 in MppPlatformService::MppPlatformService() (/usr/lib/librockchip_mpp.so.1+0x871d7)
        #4 0x7f97d6b64f in mpp_get_vcodec_type (/usr/lib/librockchip_mpp.so.1+0x8764f)
        #5 0x7f97d38da3 in hal_h264d_init (/usr/lib/librockchip_mpp.so.1+0x54da3)
        #6 0x7f97d387c7 in mpp_hal_init (/usr/lib/librockchip_mpp.so.1+0x547c7)
        #7 0x7f97d02ad3 in mpp_dec_init (/usr/lib/librockchip_mpp.so.1+0x1ead3)
        #8 0x7f97cfda3f in Mpp::init(MppCtxType, MppCodingType) (/usr/lib/librockchip_mpp.so.1+0x19a3f)
        #9 0x7f97d0056f in mpp_init (/usr/lib/librockchip_mpp.so.1+0x1c56f)
        #10 0x404347 in mpi_dec_test_decode (/home/root/rockchip-mpp-test/mpi_dec_test+0x404347)
        #11 0x4057b3 in main (/home/root/rockchip-mpp-test/mpi_dec_test+0x4057b3)
        #12 0x7f97bba563 in __libc_start_main (/lib/libc.so.6+0x1f563)
        #13 0x402217  (/home/root/rockchip-mpp-test/mpi_dec_test+0x402217)

    SUMMARY: AddressSanitizer: heap-buffer-overflow (/usr/lib/libasan.so.3+0x4215f)
    Shadow bytes around the buggy address:
      0x1ff2800480: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x1ff2800490: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x1ff28004a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x1ff28004b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x1ff28004c0: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
    =>0x1ff28004d0: 00 00 00 00[fa]fa fa fa fa fa fa fa 00 00 00 00
      0x1ff28004e0: 00 00 00 00 00 00 00 00 fa fa fa fa fa fa fa fa
      0x1ff28004f0: 00 00 00 00 00 00 00 00 00 00 00 00 fa fa fa fa
      0x1ff2800500: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x1ff2800510: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x1ff2800520: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
    Shadow byte legend (one shadow byte represents 8 application bytes):
      Addressable:           00
      Partially addressable: 01 02 03 04 05 06 07
      Heap left redzone:       fa

Signed-off-by: Yann Dirson <yann@blade-group.com>