### PR TITLE
Further fix for null nalu issue on commit 7b46386

### DIFF
--- a/mpp/codec/dec/h264/h264d_parse.c
+++ b/mpp/codec/dec/h264/h264d_parse.c
@@ -577,10 +577,8 @@ MPP_RET parse_prepare(H264dInputCtx_t *p_Inp, H264dCurCtx_t *p_Cur)
 
         if (p_strm->endcode_found) {
             p_strm->nalu_len -= START_PREFIX_3BYTE;
-            if (p_strm->nalu_len > START_PREFIX_3BYTE) {
-                while (p_strm->nalu_buf[p_strm->nalu_len - 1] == 0x00) {
-                    p_strm->nalu_len--;
-                }
+            while (p_strm->nalu_len > START_PREFIX_3BYTE && p_strm->nalu_buf[p_strm->nalu_len - 1] == 0x00) {
+                p_strm->nalu_len--;
             }
             p_Dec->nalu_ret = EndOfNalu;
             FUN_CHECK(ret = store_cur_nalu(p_Cur, &p_Dec->p_Cur->strm, p_Dec->dxva_ctx));


### PR DESCRIPTION
Respecting the case descripted in the commit 7b46386, "00 00 00 01 00 00 01", parser should jump over it. However, with the previous fix, if statement is only hit at the first time and p_strm->nalu_len-- could still get 0xffffffff and lead to the segmentfault. 