### PR TITLE
Fix build with gcc 10

### DIFF
--- a/mpp/codec/dec/h264/h264d_global.h
+++ b/mpp/codec/dec/h264/h264d_global.h
@@ -142,7 +142,7 @@ if ((val) < 0) {\
 enum {
     H264ScalingList4x4Length = 16,
     H264ScalingList8x8Length = 64,
-} ScalingListLength;
+} extern ScalingListLength;
 
 typedef enum {
     STRUCT_NULL  = 0,

--- a/mpp/hal/common/h264/hal_h264e_com.h
+++ b/mpp/hal/common/h264/hal_h264e_com.h
@@ -311,9 +311,9 @@ MPP_RET h264e_set_sps(H264eHalContext *ctx, H264eSps *sps);
 MPP_RET h264e_set_pps(H264eHalContext *ctx, H264ePps *pps, H264eSps *sps);
 void h264e_set_param(H264eHalParam *p, RK_S32 hw_type);
 
-const RK_U8 * const h264e_cqm_jvt[8];
-const RK_U8 h264e_zigzag_scan4[2][16];
-const RK_U8 h264e_zigzag_scan8[2][64];
+extern const RK_U8 * const h264e_cqm_jvt[8];
+extern const RK_U8 h264e_zigzag_scan4[2][16];
+extern const RK_U8 h264e_zigzag_scan8[2][64];
 void h264e_rkv_set_format(H264eHwCfg *hw_cfg, MppEncPrepCfg *prep_cfg);
 void h264e_vpu_set_format(H264eHwCfg *hw_cfg, MppEncPrepCfg *prep_cfg);
 void h264e_sei_pack2str(char *str, H264eHalContext *ctx, RcSyntax *rc_syn);


### PR DESCRIPTION
gcc 10 uses `-fno-common` by default. It means that global variables must be declared with the `extern` keyword, otherwise a link error will occur.

Explanation:
https://gcc.gnu.org/gcc-10/porting_to.html#common.
