### PR TITLE
fix  in mpp.pc vpu.pc for crosscompile.

### DIFF
--- a/pkgconfig/rockchip_mpp.pc.cmake
+++ b/pkgconfig/rockchip_mpp.pc.cmake
@@ -1,4 +1,4 @@
-prefix=/usr
+prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@

--- a/pkgconfig/rockchip_vpu.pc.cmake
+++ b/pkgconfig/rockchip_vpu.pc.cmake
@@ -1,4 +1,4 @@
-prefix=/usr
+prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@


### PR DESCRIPTION
In pc file it's default set $prefix to /usr that will corruput when using cmake -DCMAKE_INSTALL_PREFIX:PATH="${PREFIX}".
So I modify it to prefix=@CMAKE_INSTALL_PREFIX@.