### PR TITLE
[rga]: fix bug of rga rgb2yuv

### DIFF
--- a/mpp/vproc/rga/rga.cpp
+++ b/mpp/vproc/rga/rga.cpp
@@ -55,7 +55,7 @@ static int is_yuv_format(int fmt)
         return 1;
     }
 
-    return -1;
+    return 0;
 }
 
 static int is_rgb_format(int fmt)
@@ -64,7 +64,7 @@ static int is_rgb_format(int fmt)
         return 1;
     }
 
-    return -1;
+    return 0;
 }
 
 static RgaFormat rga_fmt_map(MppFrameFormat fmt)
@@ -248,7 +248,7 @@ MPP_RET rga_control(RgaCtx ctx, RgaCmd cmd, void *param)
         }
 
         MppFrame *src = (MppFrame *)param;
-        config_rga_image(&request->src, src);
+        ret = config_rga_image(&request->src, src);
     } break;
     case RGA_CMD_SET_DST : {
         if (NULL == param) {
@@ -258,7 +258,7 @@ MPP_RET rga_control(RgaCtx ctx, RgaCmd cmd, void *param)
         }
 
         MppFrame *dst = (MppFrame *)param;
-        config_rga_image(&request->dst, dst);
+        ret = config_rga_image(&request->dst, dst);
         // When config dst setup default clip
         RK_U32 width  = mpp_frame_get_width(dst);
         RK_U32 height = mpp_frame_get_height(dst);


### PR DESCRIPTION
# fix:
- Unsupported input format won't trigger an error.
- RGB to YUV input will be processed as YUV to RGB.