### PR TITLE
[hal_vp8e]: Fix vp8 upd prob error

### DIFF
--- a/mpp/hal/vpu/vp8e/hal_vp8e_entropy.c
+++ b/mpp/hal/vpu/vp8e/hal_vp8e_entropy.c
@@ -115,7 +115,7 @@ MPP_RET vp8e_init_entropy(void *hal)
 
                     for (l = 2; l--;) {
                         old_p = entropy->coeff_prob[i][j][k][l];
-                        old_p = coeff_update_prob_tbl[i][j][k][l];
+                        upd_p = coeff_update_prob_tbl[i][j][k][l];
 
                         tmp -= 4 * 7 * 3;
                         ii = offset_tbl[tmp];


### PR DESCRIPTION
When I looked at this func:

> +static void rockchip_vpu2_vp8_enc_update_entropy(struct hantro_ctx *ctx)


> +				for (l = 2; l--;) {
> +					old_p = entropy->coeff_prob[i][j][k][l];
> +					old_p = coeff_update_prob[i][j][k][l];
> +

The second "old_p" in "old_p = coeff_update_prob[i][j][k][l];" is very strange, it may be "upd_p".
https://lore.kernel.org/linux-rockchip/TY3P286MB2886879B6489BA89D9CD6B78A3729@TY3P286MB2886.JPNP286.PROD.OUTLOOK.COM/