### PR TITLE
fix[h265e]: fix the profile tier cfg

### DIFF
--- a/mpp/codec/enc/h265/h265e_api.c
+++ b/mpp/codec/enc/h265/h265e_api.c
@@ -479,6 +479,7 @@ static MPP_RET h265e_proc_h265_cfg(MppEncH265Cfg *dst, MppEncH265Cfg *src)
         }
 
         dst->level = src->level;
+        dst->tier = (src->level >= 120) ? src->tier : 0;
     }
 
     if (change & MPP_ENC_H265_CFG_CU_CHANGE) {


### PR DESCRIPTION
- fix[h265e]: fix the profile tier cfg (fixes ce48aeb)

cc @HermanChen 