### PR TITLE
fix crash after init vepu buffer failure

### DIFF
--- a/mpp/hal/rkenc/h264e/hal_h264e_vepu580.c
+++ b/mpp/hal/rkenc/h264e/hal_h264e_vepu580.c
@@ -214,8 +214,10 @@ static MPP_RET hal_h264e_vepu580_deinit(void *hal)
 
     clear_ext_line_bufs(p);
 
-    for (i = 0; i < p->task_cnt; i++)
-        h264e_vepu_stream_amend_deinit(&p->amend_sets[i]);
+    if (p->amend_sets != NULL) {
+        for (i = 0; i < p->task_cnt; i++)
+            h264e_vepu_stream_amend_deinit(&p->amend_sets[i]);
+    }
 
     MPP_FREE(p->regs_sets);
     MPP_FREE(p->amend_sets);


### PR DESCRIPTION
If initialization fails as follows:

```
Apr 13 12:38:23 rock-5b mpp[9997]: hal_h264e_vepu580: hal_h264e_vepu580_init init vepu buffer failed ret: -1
```

...then `hal_h264e_vepu580_init` calls `h264e_vepu_stream_amend_deinit` before initializing `amend_sets`, which goes badly:

```
(lldb) frame select 1
frame #1: 0x0000007ff4b3d77c
librockchip_mpp.so`hal_h264e_vepu580_deinit(hal=0x0000007ff000b5a0) at
hal_h264e_vepu580.c:218:9
   215      clear_ext_line_bufs(p);
   216
   217      for (i = 0; i < p->task_cnt; i++)
-> 218          h264e_vepu_stream_amend_deinit(&p->amend_sets[i]);
   219
   220      MPP_FREE(p->regs_sets);
   221      MPP_FREE(p->amend_sets);
(lldb) print p->amend_sets
(HalH264eVepuStreamAmend *) $0 = 0x0000000000000000
```