### PR TITLE
Fix static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,8 +294,7 @@ endif(MSVC)
 # ----------------------------------------------------------------------------
 # Share library option
 # ----------------------------------------------------------------------------
-option(ENABLE_STATIC "Build shared library" ON)
-option(ENABLE_SHARED "Build shared library" OFF)
+option(BUILD_SHARED_LIBS "Build shared library" ON)
 
 # ----------------------------------------------------------------------------
 # scan all LOG_TAG for log information and generate module header file

--- a/merge_static_lib.sh
+++ b/merge_static_lib.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+cd $1
+rm -rf mpp/lib'$2$'.a
+
+SCRIPT=$'CREATE mpp/lib'$2$'.a\n'
+SCRIPT=$SCRIPT$(find . -name '*.a' -exec echo 'ADDLIB {}' \;)
+SCRIPT=$SCRIPT$'\nSAVE\nEND\n'
+
+ar -M <<< $SCRIPT

--- a/mpp/CMakeLists.txt
+++ b/mpp/CMakeLists.txt
@@ -49,22 +49,6 @@ set (MPP_SRC
 set(MPP_VERSION "0")
 set(MPP_ABI_VERSION "1")
 
-add_library(${MPP_STATIC} STATIC ${MPP_SRC})
-set_target_properties(${MPP_STATIC} PROPERTIES FOLDER "mpp" OUTPUT_NAME "${MPP_SHARED}")
-set_target_properties(${MPP_STATIC} PROPERTIES CLEAN_DIRECT_OUTPUT 1)
-target_link_libraries(${MPP_STATIC} mpp_codec mpp_hal mpp_vproc
-    ${BEGIN_WHOLE_ARCHIVE} mpp_base ${END_WHOLE_ARCHIVE})
-
-add_custom_command(TARGET ${MPP_STATIC} POST_BUILD
-    COMMAND ${CMAKE_AR} x $<TARGET_FILE:${MPP_STATIC}>
-    COMMAND ${CMAKE_AR} x $<TARGET_FILE:osal>
-    COMMAND ${CMAKE_AR} x $<TARGET_FILE:mpp_base>
-    COMMAND ${CMAKE_AR} rcs lib${MPP_SHARED}.a *.o
-    COMMAND ${CMAKE_STRIP} --strip-debug lib${MPP_SHARED}.a
-    COMMAND pwd
-    COMMAND rm *.o
-    )
-
 add_library(${MPP_SHARED} SHARED ${MPP_SRC})
 set_target_properties(${MPP_SHARED} PROPERTIES FOLDER "mpp")
 set_target_properties(${MPP_SHARED} PROPERTIES CLEAN_DIRECT_OUTPUT 1)
@@ -82,5 +66,22 @@ endif()
 
 add_subdirectory(legacy)
 
-install(TARGETS ${MPP_SHARED} LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
-install(TARGETS ${MPP_STATIC} ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+if(BUILD_SHARED_LIBS)
+    install(TARGETS ${MPP_SHARED} LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+
+else()
+    add_library(${MPP_STATIC} STATIC ${MPP_SRC})
+    set_target_properties(${MPP_STATIC} PROPERTIES FOLDER "mpp")
+    set_target_properties(${MPP_STATIC} PROPERTIES CLEAN_DIRECT_OUTPUT 1)
+    target_link_libraries(${MPP_STATIC} mpp_codec mpp_hal mpp_vproc
+        ${BEGIN_WHOLE_ARCHIVE} mpp_base ${END_WHOLE_ARCHIVE})
+
+    add_custom_command(TARGET ${MPP_STATIC} POST_BUILD
+    COMMAND ${CMAKE_SOURCE_DIR}/merge_static_lib.sh ${CMAKE_BINARY_DIR} ${MPP_SHARED}
+    COMMAND ${CMAKE_STRIP} --strip-debug ${CMAKE_BINARY_DIR}/mpp/lib${MPP_SHARED}.a
+    COMMENT "Building a merged static lib."
+    )
+
+    install(FILES ${CMAKE_BINARY_DIR}/mpp/lib${MPP_SHARED}.a TYPE LIB)
+
+endif()

--- a/mpp/CMakeLists.txt
+++ b/mpp/CMakeLists.txt
@@ -49,39 +49,37 @@ set (MPP_SRC
 set(MPP_VERSION "0")
 set(MPP_ABI_VERSION "1")
 
-add_library(${MPP_SHARED} SHARED ${MPP_SRC})
+if(BUILD_SHARED_LIBS)
+    add_library(${MPP_SHARED} SHARED ${MPP_SRC})
+    target_link_libraries(${MPP_SHARED} ${ASAN_LIB})
+    set_target_properties(${MPP_SHARED} PROPERTIES C_VISIBILITY_PRESET default)
+    set_target_properties(${MPP_SHARED} PROPERTIES CXX_VISIBILITY_PRESET default)
+
+    # NOTE: due to legacy libray naming issue we can not support version on Android
+    if (NOT ANDROID)
+    set_target_properties(${MPP_SHARED} PROPERTIES VERSION ${MPP_VERSION})
+    set_target_properties(${MPP_SHARED} PROPERTIES SOVERSION ${MPP_ABI_VERSION})
+    endif()
+else()
+    add_library(${MPP_SHARED} STATIC ${MPP_SRC})
+endif()
+
 set_target_properties(${MPP_SHARED} PROPERTIES FOLDER "mpp")
 set_target_properties(${MPP_SHARED} PROPERTIES CLEAN_DIRECT_OUTPUT 1)
-target_link_libraries(${MPP_SHARED} mpp_codec mpp_hal mpp_vproc ${ASAN_LIB}
+target_link_libraries(${MPP_SHARED} mpp_codec mpp_hal mpp_vproc
                       ${BEGIN_WHOLE_ARCHIVE} mpp_base ${END_WHOLE_ARCHIVE})
-set_target_properties(${MPP_SHARED} PROPERTIES C_VISIBILITY_PRESET default)
-set_target_properties(${MPP_SHARED} PROPERTIES CXX_VISIBILITY_PRESET default)
-
-# NOTE: due to legacy libray naming issue we can not support version on Android
-if (NOT ANDROID)
-set_target_properties(${MPP_SHARED} PROPERTIES VERSION ${MPP_VERSION})
-set_target_properties(${MPP_SHARED} PROPERTIES SOVERSION ${MPP_ABI_VERSION})
-endif()
 
 
 add_subdirectory(legacy)
 
 if(BUILD_SHARED_LIBS)
     install(TARGETS ${MPP_SHARED} LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
-
 else()
-    add_library(${MPP_STATIC} STATIC ${MPP_SRC})
-    set_target_properties(${MPP_STATIC} PROPERTIES FOLDER "mpp")
-    set_target_properties(${MPP_STATIC} PROPERTIES CLEAN_DIRECT_OUTPUT 1)
-    target_link_libraries(${MPP_STATIC} mpp_codec mpp_hal mpp_vproc
-        ${BEGIN_WHOLE_ARCHIVE} mpp_base ${END_WHOLE_ARCHIVE})
-
-    add_custom_command(TARGET ${MPP_STATIC} POST_BUILD
-    COMMAND ${CMAKE_SOURCE_DIR}/merge_static_lib.sh ${CMAKE_BINARY_DIR} ${MPP_SHARED}
+    add_custom_command(TARGET ${MPP_SHARED} POST_BUILD
+    COMMAND ${CMAKE_SOURCE_DIR}/merge_static_lib.sh ${CMAKE_BINARY_DIR} ${MPP_SHARED}_merged
     COMMAND ${CMAKE_STRIP} --strip-debug ${CMAKE_BINARY_DIR}/mpp/lib${MPP_SHARED}.a
     COMMENT "Building a merged static lib."
     )
 
-    install(FILES ${CMAKE_BINARY_DIR}/mpp/lib${MPP_SHARED}.a TYPE LIB)
-
+    install(FILES ${CMAKE_BINARY_DIR}/mpp/lib${MPP_SHARED}_merged.a TYPE LIB RENAME lib${MPP_SHARED}.a)
 endif()


### PR DESCRIPTION
When working with the new static build, I stumbled across two problems:
1. The current implementation always installs shared and static libraries. This can lead to build errors. It is better to either install the shared or static files.
2. The current static `librochchip_mpp.a` lacks most symbols. When using static libraries, the cmake command `target_link_libraries` will not add the definitions from one static library to another. Therefore to get a fully working static lib, one has to merge all libraries that were created during the build process.

This PR fixes both issues.