### PR TITLE
drop master on /dev/dri/card0 by default

### DIFF
--- a/osal/allocator/allocator_drm.c
+++ b/osal/allocator/allocator_drm.c
@@ -183,8 +183,17 @@ static MPP_RET os_allocator_drm_open(void **ctx, size_t alignment, MppAllocFlagT
 
     for (i = 0; i < (RK_S32)MPP_ARRAY_ELEMS(dev_drm); i++) {
         fd = open(dev_drm[i], O_RDWR | O_CLOEXEC);
-        if (fd > 0)
+        if (fd > 0) {
+
+            if (strcmp(dev_drm[i], "/dev/dri/card0") == 0) {
+                int ret = drm_ioctl(fd, DRM_IOCTL_DROP_MASTER, 0);
+                if (ret < 0) {
+                    mpp_err_f("Drop master on %s failed!\n", dev_drm[i]);
+                }
+            }
+
             break;
+        }
     }
 
     if (fd < 0) {


### PR DESCRIPTION


This is a really odd edge case, but if you initialize a mpp buffer first and then later try to get the drm master to draw a user interface using another part of your program, you'll be unable to modeset.

This is because drm automatically sets the first file to open as the drm master.

Most people won't run into this issue (or I assume they won't) because they are already likely using a desktop environment (which will already claim the drm master), they are completely running as headless process, and/or they aren't initializing  the mpp buffer before their UI.

I was lucky enough to have none of those as my setup, so ran head first into this problem.

The other way around this is to open a temporary file to /dev/dri/card0 before calling the mpp buffer code in your user code.  I'm specifically using ffmpeg rockchip and running into this.

See also here: https://github.com/nyanmisaka/mpp/pull/1
