### PR TITLE
fix[vepu580]: fix is_yuv/is_fbc typo

### DIFF
--- a/mpp/hal/rkenc/h265e/hal_h265e_vepu580.c
+++ b/mpp/hal/rkenc/h265e/hal_h265e_vepu580.c
@@ -2000,7 +2000,7 @@ static MPP_RET vepu580_h265_set_pp_regs(H265eV580RegSet *regs, VepuFmtCfg *fmt,
     reg_base->reg0203_src_proc.src_mirr = prep_cfg->mirroring > 0;
     reg_base->reg0203_src_proc.src_rot = prep_cfg->rotation;
 
-    if (MPP_FRAME_FMT_IS_FBC(prep_cfg->format))
+    if (MPP_FRAME_FMT_IS_YUV(prep_cfg->format))
         reg_base->reg0198_src_fmt.src_range = 1;
     else
         reg_base->reg0198_src_fmt.src_range = (prep_cfg->range == MPP_FRAME_RANGE_JPEG) ? 1 : 0;


### PR DESCRIPTION
`MPP_FRAME_FMT_IS_YUV()` should be used.

fixes 5f522dc

```
fix[vepu580]: fix incorrect color range problem

For H.264 and H.265 encoder on RK3588, when input source is YUV, keep
input source. For RGB, transalting according range setting from API.
```

cc @HermanChen