### PR TITLE
fix[vdpu383]: fix uninitialized fbc_hdr_stride

### DIFF
--- a/mpp/codec/dec/av1/av1d_parser.c
+++ b/mpp/codec/dec/av1/av1d_parser.c
@@ -782,6 +782,8 @@ static MPP_RET get_current_frame(Av1CodecContext *ctx)
     mpp_frame_set_content_light(frame->f, s->content_light);
 
     if (MPP_FRAME_FMT_IS_FBC(s->cfg->base.out_fmt)) {
+        RK_U32 fbc_hdr_stride = MPP_ALIGN(ctx->width, 64);
+
         mpp_slots_set_prop(s->slots, SLOTS_HOR_ALIGN, hor_align_16);
         if (s->bit_depth == 10) {
             if ((ctx->pix_fmt & MPP_FRAME_FMT_MASK) == MPP_FMT_YUV420SP ||
@@ -796,6 +798,11 @@ static MPP_RET get_current_frame(Av1CodecContext *ctx)
         mpp_frame_set_offset_y(frame->f, 0);
         if (mpp_get_soc_type() == ROCKCHIP_SOC_RK3588)
             mpp_frame_set_ver_stride(frame->f, MPP_ALIGN(ctx->height, 8) + 28);
+
+        if (*compat_ext_fbc_hdr_256_odd)
+            fbc_hdr_stride = MPP_ALIGN(ctx->width, 256) | 256;
+
+        mpp_frame_set_fbc_hdr_stride(frame->f, fbc_hdr_stride);
     } else if (MPP_FRAME_FMT_IS_TILE(s->cfg->base.out_fmt)) {
         ctx->pix_fmt |= s->cfg->base.out_fmt & (MPP_FRAME_TILE_FLAG);
     }


### PR DESCRIPTION
Fixes aaa4c8e for rk3576 av1d rkfbc use case.

Otherwise it crashes the RGA driver.
```
rk_iommu 27920f00.iommu: Page fault at 0x0000000002010040 of type read
rk_iommu 27920f00.iommu: iova = 0x0000000002010040: dte_index: 0x8 pte_index: 0x10 page_offset: 0x40
rk_iommu 27920f00.iommu: mmu_dte_addr: 0x00000000434c3000 dte@0x00000000434c3020: 0x000000 valid: 0>
rga: 0      0     : IOMMU intr fault, IOVA[0x2010040], STATUS[0x24b]
rga: 0      0     : RGA2_core0[0x4] soft reset complete.
rga: 0      0     : RGA IOMMU: page fault! Please check the memory size.
rk_iommu 27920f00.iommu: Page fault at 0x0000000002020080 of type read
rk_iommu 27920f00.iommu: iova = 0x0000000002020080: dte_index: 0x8 pte_index: 0x20 page_offset: 0x80
rk_iommu 27920f00.iommu: mmu_dte_addr: 0x00000000434c3000 dte@0x00000000434c3020: 0x000000 valid: 0>
rga: 0      0     : IOMMU intr fault, IOVA[0x2020080], STATUS[0x24b]
rga: 0      0     : RGA2_core0[0x4] soft reset complete.
rga: 0      0     : RGA IOMMU: page fault! Please check the memory size.
rk_iommu 27920f00.iommu: Page fault at 0x00000000f960c830 of type read
rk_iommu 27920f00.iommu: iova = 0x00000000f960c830: dte_index: 0x3e5 pte_index: 0x20c page_offset: >
rk_iommu 27920f00.iommu: mmu_dte_addr: 0x00000000434c3000 dte@0x00000000434c3f94: 0x000000 valid: 0>
rga: 0      0     : IOMMU intr fault, IOVA[0xf960c830], STATUS[0x24b]
rga: 0      0     : RGA2_core0[0x4] soft reset complete.
rga: 0      0     : RGA IOMMU: page fault! Please check the memory size.
rk_iommu 27920f00.iommu: Page fault at 0x00000000f7615850 of type read
rk_iommu 27920f00.iommu: iova = 0x00000000f7615850: dte_index: 0x3dd pte_index: 0x215 page_offset: >
rk_iommu 27920f00.iommu: mmu_dte_addr: 0x00000000434c3000 dte@0x00000000434c3f74: 0x000000 valid: 0>
rga: 0      0     : IOMMU intr fault, IOVA[0xf7615850], STATUS[0x24b]
rga: 0      0     : RGA2_core0[0x4] soft reset complete.
rga: 0      0     : RGA IOMMU: page fault! Please check the memory size.
```

cc @HermanChen