### PR TITLE
fix[mpp]: Fix input_task_count for async enc

### DIFF
--- a/mpp/mpp.cpp
+++ b/mpp/mpp.cpp
@@ -208,7 +208,7 @@ MPP_RET Mpp::init(MppCtxType type, MppCodingType coding)
         mInitDone = 1;
     } break;
     case MPP_CTX_ENC : {
-        RK_S32 input_task_count = 1;
+        mInputTaskCount = 1;
 
         mPktOut = new mpp_list(list_wraper_packet);
         mFrmIn  = new mpp_list(list_wraper_frame);
@@ -241,7 +241,7 @@ MPP_RET Mpp::init(MppCtxType type, MppCodingType coding)
 
         MppEncInitCfg cfg = {
             coding,
-            input_task_count,
+            mInputTaskCount,
             this,
         };
 


### PR DESCRIPTION
fix[mpp]: Fix input_task_count for async enc

fixes 22308f0

Otherwise async encode only allows one input task and performs at the same speed as blocking i/o encode.

cc @HermanChen