### PR TITLE
fix[vproc]: Fix unit tests cannot be disabled

### DIFF
--- a/mpp/vproc/iep/test/CMakeLists.txt
+++ b/mpp/vproc/iep/test/CMakeLists.txt
@@ -4,7 +4,9 @@
 # ----------------------------------------------------------------------------
 # iep unit test
 option(IEP_TEST "Build base iep unit test" ${BUILD_TEST})
-add_executable(iep_test iep_test.cpp)
-target_link_libraries(iep_test ${MPP_SHARED} utils)
-set_target_properties(iep_test PROPERTIES FOLDER "mpp/vproc/iep")
-add_test(NAME iep_test COMMAND iep_test)
+if (IEP_TEST)
+    add_executable(iep_test iep_test.cpp)
+    target_link_libraries(iep_test ${MPP_SHARED} utils)
+    set_target_properties(iep_test PROPERTIES FOLDER "mpp/vproc/iep")
+    add_test(NAME iep_test COMMAND iep_test)
+endif()

--- a/mpp/vproc/iep2/test/CMakeLists.txt
+++ b/mpp/vproc/iep2/test/CMakeLists.txt
@@ -3,8 +3,10 @@
 # mpp/vproc/iep2 built-in unit test case
 # ----------------------------------------------------------------------------
 # iep2 unit test
-option(IEP2_TEST "Build base iep2 unit test" ON)
-add_executable(iep2_test iep2_test.c)
-target_link_libraries(iep2_test ${MPP_SHARED} utils)
-set_target_properties(iep2_test PROPERTIES FOLDER "mpp/vproc/iep2")
-add_test(NAME iep2_test COMMAND iep2_test)
+option(IEP2_TEST "Build base iep2 unit test" ${BUILD_TEST})
+if (IEP2_TEST)
+    add_executable(iep2_test iep2_test.c)
+    target_link_libraries(iep2_test ${MPP_SHARED} utils)
+    set_target_properties(iep2_test PROPERTIES FOLDER "mpp/vproc/iep2")
+    add_test(NAME iep2_test COMMAND iep2_test)
+endif()

--- a/mpp/vproc/rga/test/CMakeLists.txt
+++ b/mpp/vproc/rga/test/CMakeLists.txt
@@ -4,7 +4,9 @@
 # ----------------------------------------------------------------------------
 # rga unit test
 option(RGA_TEST "Build base rga unit test" ${BUILD_TEST})
-add_executable(rga_test rga_test.cpp)
-target_link_libraries(rga_test ${MPP_SHARED} utils)
-set_target_properties(rga_test PROPERTIES FOLDER "mpp/vproc/rga")
-add_test(NAME rga_test COMMAND rga_test)
+if (RGA_TEST)
+    add_executable(rga_test rga_test.cpp)
+    target_link_libraries(rga_test ${MPP_SHARED} utils)
+    set_target_properties(rga_test PROPERTIES FOLDER "mpp/vproc/rga")
+    add_test(NAME rga_test COMMAND rga_test)
+endif()

--- a/mpp/vproc/vdpp/test/CMakeLists.txt
+++ b/mpp/vproc/vdpp/test/CMakeLists.txt
@@ -3,14 +3,16 @@
 # mpp/vproc/vdpp built-in unit test case
 # ----------------------------------------------------------------------------
 # vdpp unit test
-option(VDPP_TEST "Build base vdpp unit test" ON)
-add_executable(vdpp_test vdpp_test.c)
-target_link_libraries(vdpp_test ${MPP_SHARED} utils vproc_vdpp)
-set_target_properties(vdpp_test PROPERTIES FOLDER "mpp/vproc/vdpp")
-add_test(NAME vdpp_test COMMAND vdpp_test)
+option(VDPP_TEST "Build base vdpp unit test" ${BUILD_TEST})
+if (VDPP_TEST)
+    add_executable(vdpp_test vdpp_test.c)
+    target_link_libraries(vdpp_test ${MPP_SHARED} utils vproc_vdpp)
+    set_target_properties(vdpp_test PROPERTIES FOLDER "mpp/vproc/vdpp")
+    add_test(NAME vdpp_test COMMAND vdpp_test)
 
-# hwpq test (call libvdpp.so)
-add_executable(hwpq_test hwpq_test.cpp)
-target_link_libraries(hwpq_test vdpp ${ASAN_LIB})
-set_target_properties(hwpq_test PROPERTIES FOLDER "mpp/vproc/vdpp")
-add_test(NAME hwpq_test COMMAND hwpq_test)
+    # hwpq test (call libvdpp.so)
+    add_executable(hwpq_test hwpq_test.cpp)
+    target_link_libraries(hwpq_test vdpp ${ASAN_LIB})
+    set_target_properties(hwpq_test PROPERTIES FOLDER "mpp/vproc/vdpp")
+    add_test(NAME hwpq_test COMMAND hwpq_test)
+endif()


### PR DESCRIPTION
Fix some unit tests in `vproc` not following `-D BUILD_TEST=OFF` setting.