### PR TITLE
Prepend bash with /usr/bin/env

### DIFF
--- a/merge_static_lib.sh
+++ b/merge_static_lib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd $1
 rm -rf mpp/lib'$2$'.a


### PR DESCRIPTION
There is no `/bin/bash` on some Linux systems like NixOS.