### PR TITLE
fix[hwpq_test] Fix building tests against musl libc

### DIFF
--- a/mpp/vproc/vdpp/test/hwpq_test.cpp
+++ b/mpp/vproc/vdpp/test/hwpq_test.cpp
@@ -7,6 +7,7 @@
 
 #include <getopt.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <stdio.h>
 #include <pthread.h>


### PR DESCRIPTION
It fails with errors like:

```
  /project/vendor/rockchip-mpp/mpp/vproc/vdpp/test/hwpq_test.cpp:42:5: error: 'int32_t' does not name a type
     42 |     int32_t      nthreads;
        |     ^~~~~~~
  /project/vendor/rockchip-mpp/mpp/vproc/vdpp/test/hwpq_test.cpp:43:5: error: 'int32_t' does not name a type
     43 |     int32_t      frame_num;
        |     ^~~~~~~
```
