### PR TITLE
fix[build]: Fix issues found by strict compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,9 +124,9 @@ endif()
 
 if(${CMAKE_BUILD_TYPE} MATCHES "Release")
     # remove -g option for high version ndk
-    string(REGEX REPLACE "-g[^ ]*" "" TMP "${CMAKE_C_FLAGS}")
+    string(REGEX REPLACE "(^|[ \t])-g([0-9]+)?([ \t]|$)" " " TMP "${CMAKE_C_FLAGS}")
     string(REGEX REPLACE "[ ]+" " " CMAKE_C_FLAGS "${TMP}")
-    string(REGEX REPLACE "-g[^ ]*" "" TMP "${CMAKE_CXX_FLAGS}")
+    string(REGEX REPLACE "(^|[ \t])-g([0-9]+)?([ \t]|$)" " " TMP "${CMAKE_CXX_FLAGS}")
     string(REGEX REPLACE "[ ]+" " " CMAKE_CXX_FLAGS "${TMP}")
 
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -DNDEBUG")

--- a/kmpp/base/inc/kmpp_obj_helper.h
+++ b/kmpp/base/inc/kmpp_obj_helper.h
@@ -605,12 +605,16 @@ rk_s32 CONCAT_US(KMPP_OBJ_NAME, size)(void)
     return kmpp_objdef_get_entry_size(KMPP_OBJ_DEF(KMPP_OBJ_NAME));
 }
 
-rk_s32 CONCAT_US(KMPP_OBJ_NAME, get)(KMPP_OBJ_INTF_TYPE *obj)
+#ifndef KMPP_OBJ_RET_TYPE
+#define KMPP_OBJ_RET_TYPE rk_s32
+#endif
+
+KMPP_OBJ_RET_TYPE CONCAT_US(KMPP_OBJ_NAME, get)(KMPP_OBJ_INTF_TYPE *obj)
 {
     return kmpp_obj_get_f((KmppObj *)obj, KMPP_OBJ_DEF(KMPP_OBJ_NAME));
 }
 
-rk_s32 CONCAT_US(KMPP_OBJ_NAME, put)(KMPP_OBJ_INTF_TYPE obj)
+KMPP_OBJ_RET_TYPE CONCAT_US(KMPP_OBJ_NAME, put)(KMPP_OBJ_INTF_TYPE obj)
 {
     return kmpp_obj_put_f(obj);
 }
@@ -792,6 +796,7 @@ extern "C" {
 
 #endif /* KMPP_OBJ_FUNC_IOCTL */
 
+#undef KMPP_OBJ_RET_TYPE
 #undef KMPP_OBJ_NAME
 #undef KMPP_OBJ_INTF_TYPE
 #undef KMPP_OBJ_IMPL_TYPE

--- a/kmpp/base/kmpp_venc_cfg.c
+++ b/kmpp/base/kmpp_venc_cfg.c
@@ -256,7 +256,7 @@ MPP_RET mpp_venc_ctrl_set_flex(MppVencKcfg ctrl, const void *data, RK_U32 size)
     return MPP_NOK;
 }
 
-rk_s32 kmpp_venc_ref_cfg_check(MppVencKcfg ref)
+MPP_RET kmpp_venc_ref_cfg_check(MppVencKcfg ref)
 {
     if (ref_cfg_check_cmd < 0 || !ref)
         return rk_nok;

--- a/mpp/base/mpp_enc_cfg.c
+++ b/mpp/base/mpp_enc_cfg.c
@@ -366,14 +366,14 @@ MPP_RET mpp_enc_cfg_init(MppEncCfg *cfg)
     return mpp_enc_cfg_get(cfg);
 }
 
-RK_S32 mpp_enc_cfg_init_k(MppEncCfg *cfg)
+MPP_RET mpp_enc_cfg_init_k(MppEncCfg *cfg)
 {
     mpp_env_get_u32("mpp_enc_cfg_debug", &mpp_enc_cfg_debug, 0);
 
     return mpp_venc_kcfg_init(cfg, MPP_VENC_KCFG_TYPE_ST_CFG);
 }
 
-RK_S32 mpp_enc_cfg_deinit(MppEncCfg cfg)
+MPP_RET mpp_enc_cfg_deinit(MppEncCfg cfg)
 {
     return kmpp_obj_put_f(cfg);
 }

--- a/mpp/base/mpp_sys_cfg.c
+++ b/mpp/base/mpp_sys_cfg.c
@@ -75,6 +75,7 @@
     STRUCT_END(dec_buf_chk) \
     CFG_DEF_END()
 
+#define KMPP_OBJ_RET_TYPE           MPP_RET
 #define KMPP_OBJ_NAME               mpp_sys_cfg
 #define KMPP_OBJ_INTF_TYPE          MppSysCfg
 #define KMPP_OBJ_IMPL_TYPE          MppSysCfgSet

--- a/mpp/codec/enc/h264/h264e_pps.c
+++ b/mpp/codec/enc/h264/h264e_pps.c
@@ -118,7 +118,7 @@ MPP_RET h264e_pps_update(H264ePps *pps, MppEncCfgSet *cfg)
     return MPP_OK;
 }
 
-RK_S32 h264e_pps_to_packet(H264ePps *pps, MppPacket packet, RK_S32 *offset, RK_S32 *len)
+MPP_RET h264e_pps_to_packet(H264ePps *pps, MppPacket packet, RK_S32 *offset, RK_S32 *len)
 {
     void *pos = mpp_packet_get_pos(packet);
     void *data = mpp_packet_get_data(packet);

--- a/mpp/hal/rkdec/inc/vdpu38x_com.h
+++ b/mpp/hal/rkdec/inc/vdpu38x_com.h
@@ -775,7 +775,7 @@ void vdpu38x_rcb_set_pic_h(Vdpu38xRcbCtx *ctx, RK_U32 pic_h);
 RK_U32 vdpu38x_rcb_get_pic_h(Vdpu38xRcbCtx *ctx);
 void vdpu38x_rcb_set_tile_dir(Vdpu38xRcbCtx *ctx, RK_U32 tile_dir);
 RK_U32 vdpu38x_rcb_get_tile_dir(Vdpu38xRcbCtx *ctx);
-void vdpu38x_rcb_set_fmt(Vdpu38xRcbCtx *ctx, RK_U32 fmt);
+void vdpu38x_rcb_set_fmt(Vdpu38xRcbCtx *ctx, Vdpu38xFmt fmt);
 Vdpu38xFmt vdpu38x_rcb_get_fmt(Vdpu38xRcbCtx *ctx);
 void vdpu38x_rcb_set_bit_depth(Vdpu38xRcbCtx *ctx, RK_U32 bit_depth);
 RK_U32 vdpu38x_rcb_get_bit_depth(Vdpu38xRcbCtx *ctx);

--- a/mpp/vproc/vdpp/test/hwpq_test.c
+++ b/mpp/vproc/vdpp/test/hwpq_test.c
@@ -25,6 +25,24 @@
 #define VDPP_WORK_MODE_VEP  (2)
 #define VDPP_WORK_MODE_DCI  (3) /* hist only mode */
 
+static MPP_RET make_result_path(char *dst, size_t dst_size,
+                                const char *dir, const char *name)
+{
+    size_t dir_len = strlen(dir);
+    size_t name_len = strlen(name);
+
+    if (dir_len + 1 + name_len + 1 > dst_size) {
+        mpp_loge("output path is too long: %s/%s\n", dir, name);
+        return MPP_ERR_VALUE;
+    }
+
+    memcpy(dst, dir, dir_len);
+    dst[dir_len] = '/';
+    memcpy(dst + dir_len + 1, name, name_len + 1);
+
+    return MPP_OK;
+}
+
 typedef struct {
     char src_file_name[MAX_URL_LEN];
     char dst_file_name_y[MAX_URL_LEN];
@@ -266,20 +284,34 @@ static void *multi_vdpp(void *cmd_ctx)
     if (cfg->dst_dir_name[0]) {
         char filename[MAX_URL_LEN] = {0};
 
-        snprintf(filename, MAX_URL_LEN - 1, "%s/vdpp_res_com.txt", cfg->dst_dir_name);
+        if (make_result_path(filename, sizeof(filename),
+                             cfg->dst_dir_name, "vdpp_res_com.txt"))
+            goto __RET;
+
         mul_ctx->fp_o_res = fopen(filename, "wt");
         if (mul_ctx->fp_o_res == NULL) {
             mpp_logw("failed to open output com file %s! %s\n", filename, strerror(errno));
         }
 
         if (cfg->en_hist) {
-            snprintf(filename, MAX_URL_LEN - 1, "%s/vdpp_res_hist_packed.bin", cfg->dst_dir_name);
+            if (make_result_path(filename, sizeof(filename),
+                                 cfg->dst_dir_name, "vdpp_res_hist_packed.bin"))
+                goto __RET;
+
             mul_ctx->fp_o_hist = fopen(filename, "wb");
         }
+
         if (cfg->en_pyr) {
             for (i = 0; i < 3; i++) {
-                snprintf(filename, MAX_URL_LEN - 1, "%s/vdpp_res_pyr_l%d.yuv",
-                         cfg->dst_dir_name, i + 1);
+                char result_name[32];
+
+                snprintf(result_name, sizeof(result_name),
+                         "vdpp_res_pyr_l%d.yuv", i + 1);
+
+                if (make_result_path(filename, sizeof(filename),
+                                     cfg->dst_dir_name, result_name))
+                    goto __RET;
+
                 mul_ctx->fp_o_pyrs[i] = fopen(filename, "wb");
             }
         }

--- a/mpp/vproc/vdpp/test/vdpp_test.c
+++ b/mpp/vproc/vdpp/test/vdpp_test.c
@@ -26,6 +26,24 @@
 #define YUV_MAX_SIZE      (12582912) // 4096 * 2048 * 3 / 2
 #define DCI_HIST_SIZE     (10240)    // (16*16*16*18/8/4 + 256) * 4
 
+static MPP_RET make_result_path(char *dst, size_t dst_size,
+                                const char *dir, const char *name)
+{
+    size_t dir_len = strlen(dir);
+    size_t name_len = strlen(name);
+
+    if (dir_len + 1 + name_len + 1 > dst_size) {
+        mpp_loge("output path is too long: %s/%s\n", dir, name);
+        return MPP_ERR_VALUE;
+    }
+
+    memcpy(dst, dir, dir_len);
+    dst[dir_len] = '/';
+    memcpy(dst + dir_len + 1, name, name_len + 1);
+
+    return MPP_OK;
+}
+
 typedef struct VdppTestCfg_t {
     MppFrameFormat src_format; // see MppFrameFormat: 0-nv12, 15-nv24
     RK_U32 src_width;          // unit: pixel
@@ -979,26 +997,43 @@ RK_S32 main(RK_S32 argc, char **argv)
     if (cfg.out_dir[0]) {
         char filename[MAX_URL_LEN] = {0};
 
-        snprintf(filename, MAX_URL_LEN - 1, "%s/vdpp_res_com.txt", cfg.out_dir);
+        if (make_result_path(filename, sizeof(filename),
+                             cfg.out_dir, "vdpp_res_com.txt"))
+            return MPP_ERR_VALUE;
+
         cfg.fp_result = fopen(filename, "wt");
         if (cfg.fp_result == NULL) {
             mpp_logw("failed to open output com file %s! %s\n", filename, strerror(errno));
         }
 
         if (cfg.en_hist) {
-            snprintf(filename, MAX_URL_LEN - 1, "%s/vdpp_res_hist_packed.bin", cfg.out_dir);
+            if (make_result_path(filename, sizeof(filename),
+                                 cfg.out_dir, "vdpp_res_hist_packed.bin"))
+                return MPP_ERR_VALUE;
             cfg.fp_hist = fopen(filename, "wb");
 
-            snprintf(filename, MAX_URL_LEN - 1, "%s/vdpp_res_hist_local.bin", cfg.out_dir);
+            if (make_result_path(filename, sizeof(filename),
+                                 cfg.out_dir, "vdpp_res_hist_local.bin"))
+                return MPP_ERR_VALUE;
             cfg.fp_hist_l = fopen(filename, "wb");
 
-            snprintf(filename, MAX_URL_LEN - 1, "%s/vdpp_res_hist_global.bin", cfg.out_dir);
+            if (make_result_path(filename, sizeof(filename),
+                                 cfg.out_dir, "vdpp_res_hist_global.bin"))
+                return MPP_ERR_VALUE;
             cfg.fp_hist_g = fopen(filename, "wb");
         }
 
         if (cfg.en_pyr) {
             for (i = 0; i < 3; ++i) {
-                snprintf(filename, MAX_URL_LEN - 1, "%s/vdpp_res_pyr_l%d.yuv", cfg.out_dir, i + 1);
+                char result_name[32];
+
+                snprintf(result_name, sizeof(result_name),
+                         "vdpp_res_pyr_l%d.yuv", i + 1);
+
+                if (make_result_path(filename, sizeof(filename),
+                                     cfg.out_dir, result_name))
+                    return MPP_ERR_VALUE;
+
                 cfg.fp_pyrs[i] = fopen(filename, "wb");
             }
         }


### PR DESCRIPTION
This fixes issues exposed by strict compilation without changing the
default feature selection.

Changes:
- match API declarations and definitions that use MPP_RET;
- allow the KMPP object helper return type to be selected where MPP_RET
  is required while keeping rk_s32 as the default;
- align the vdpu38x format setter declaration with its implementation;
- reject overlong VDPP result paths instead of silently truncating them;
- restrict Release debug-flag removal to standalone -g/-gN options so
  unrelated compiler arguments containing a "-g" prefix are preserved.

Validation:
- RK3588S / Orange Pi 5, Linux 6.1.119-rt45-vendor-rk35xx;
- GCC 13.3.0, CMake 3.28.3, Ninja;
- Release build with WARNINGS_AS_ERRORS=ON,
  ENABLE_VPROC_VDPP=ON, ENABLE_FASTPLAY_ONCE=ON and BUILD_TEST=ON;
- 367 C/C++ compile units built with -Werror, -O3 and -DNDEBUG;
- verified that a path containing "aarch64-linux-gnu" is preserved while
  a standalone -g option is removed;
- full build completed 456/456 targets;
- mpp_info_test, mpp_sys_cfg_test and mpp_enc_cfg_test passed;
- hardware H.264 encode and fast-play decode passed.