### PR TITLE
feat[mpp_dec]: Export raw decoder COLMV metadata

### DIFF
--- a/inc/mpp_meta.h
+++ b/inc/mpp_meta.h
@@ -31,6 +31,18 @@
  * 2. Flow control metadata
  *
  */
+/*
+ * Raw decoder collocated motion-vector buffer layout.
+ * The buffer is hardware-generated and format-specific.
+ */
+typedef enum MppDecColmvFormat_e {
+    MPP_DEC_COLMV_FMT_NONE = 0,
+    MPP_DEC_COLMV_FMT_VDPU34X_H264_COMPRESSED,
+    MPP_DEC_COLMV_FMT_VDPU34X_H264_UNCOMPRESSED,
+    MPP_DEC_COLMV_FMT_VDPU34X_H265_COMPRESSED,
+    MPP_DEC_COLMV_FMT_BUTT,
+} MppDecColmvFormat;
+
 typedef enum MppMetaKey_e {
     /* data flow key */
     KEY_INPUT_FRAME             = FOURCC_META('i', 'f', 'r', 'm'),
@@ -152,6 +164,12 @@ typedef enum MppMetaKey_e {
     KEY_DEC_TBN_EN              = FOURCC_META('t', 'b', 'e', 'n'),
     KEY_DEC_TBN_Y_OFFSET        = FOURCC_META('t', 'b', 'y', 'o'),
     KEY_DEC_TBN_UV_OFFSET       = FOURCC_META('t', 'b', 'c', 'o'),
+
+    /* Raw decoder collocated motion-vector buffer and layout. */
+    KEY_DEC_COLMV               = FOURCC_META('d', 'c', 'm', 'v'),
+    KEY_DEC_COLMV_FMT           = FOURCC_META('d', 'c', 'm', 'f'),
+    /* Number of valid bytes in KEY_DEC_COLMV for this frame. */
+    KEY_DEC_COLMV_SIZE          = FOURCC_META('d', 'c', 'm', 's'),
 
     /* combo frame */
     KEY_COMBO_FRAME             = FOURCC_META('c', 'f', 'r', 'm'),

--- a/mpp/base/inc/mpp_frame_impl.h
+++ b/mpp/base/inc/mpp_frame_impl.h
@@ -150,6 +150,8 @@ struct MppFrameImpl_t {
      * NOTE: buf_size only access internally
      */
     MppBuffer       buffer;
+    /* Keep exported decoder COLMV alive for the frame lifetime. */
+    MppBuffer       colmv_buf;
     size_t          buf_size;
 
     /*
@@ -206,6 +208,8 @@ RK_U32  mpp_frame_get_fbc_offset(MppFrame frame);
 RK_U32  mpp_frame_get_fbc_stride(MppFrame frame);
 size_t  mpp_frame_get_fbc_size(MppFrame frame);
 void    mpp_frame_set_fbc_size(MppFrame frame, size_t size);
+
+void mpp_frame_set_colmv_buffer(MppFrame frame, MppBuffer buffer);
 
 MppFrameStatus *mpp_frame_get_status(MppFrame frame);
 

--- a/mpp/base/mpp_dec_cfg.c
+++ b/mpp/base/mpp_dec_cfg.c
@@ -39,6 +39,7 @@
     ENTRY(prefix, u32, rk_u32,     enable_vproc,        FLAG_INCR,      base, enable_vproc) \
     ENTRY(prefix, u32, rk_u32,     enable_fast_play,    FLAG_INCR,      base, enable_fast_play) \
     ENTRY(prefix, u32, rk_u32,     enable_hdr_meta,     FLAG_INCR,      base, enable_hdr_meta) \
+    ENTRY(prefix, u32, rk_u32,     enable_colmv,        FLAG_INCR,      base, enable_colmv) \
     ENTRY(prefix, u32, rk_u32,     enable_thumbnail,    FLAG_INCR,      base, enable_thumbnail) \
     ENTRY(prefix, u32, rk_u32,     enable_mvc,          FLAG_INCR,      base, enable_mvc) \
     ENTRY(prefix, u32, rk_u32,     disable_dpb_chk,     FLAG_INCR,      base, disable_dpb_chk) \

--- a/mpp/base/mpp_frame.c
+++ b/mpp/base/mpp_frame.c
@@ -41,6 +41,14 @@ static void hdr_meta_ref_put(MppFrameImpl *p)
     }
 }
 
+static void colmv_buf_put(MppFrameImpl *p)
+{
+    if (p->colmv_buf) {
+        mpp_buffer_put(p->colmv_buf);
+        p->colmv_buf = NULL;
+    }
+}
+
 static void setup_mpp_frame_name(MppFrameImpl *frame)
 {
     frame->name = module_name;
@@ -53,6 +61,7 @@ static void setup_mpp_frame_defaults(MppFrameImpl *frame)
     frame->color_trc = MPP_FRAME_TRC_UNSPECIFIED;
     frame->colorspace = MPP_FRAME_SPC_UNSPECIFIED;
     frame->hdr_dynamic_meta = NULL;
+    frame->colmv_buf = NULL;
 }
 
 #define check_is_mpp_frame(frame) _check_is_mpp_frame(__FUNCTION__, frame)
@@ -131,6 +140,8 @@ MPP_RET mpp_frame_deinit(MppFrame *frame)
     if (p->buffer)
         mpp_buffer_put(p->buffer);
 
+    colmv_buf_put(p);
+
     if (p->meta)
         mpp_meta_put(p->meta);
 
@@ -169,6 +180,22 @@ void mpp_frame_set_buffer(MppFrame frame, MppBuffer buffer)
             mpp_buffer_put(p->buffer);
 
         p->buffer = buffer;
+    }
+}
+
+void mpp_frame_set_colmv_buffer(MppFrame frame, MppBuffer buffer)
+{
+    MppFrameImpl *p = (MppFrameImpl *)frame;
+
+    if (check_is_mpp_frame(p))
+        return;
+
+    if (p->colmv_buf != buffer) {
+        if (buffer)
+            mpp_buffer_inc_ref(buffer);
+
+        colmv_buf_put(p);
+        p->colmv_buf = buffer;
     }
 }
 
@@ -268,6 +295,9 @@ MppFrame mpp_frame_dup(MppFrame src)
     if (p->meta)
         ret->meta = mpp_meta_dup(p->meta);
 
+    if (p->colmv_buf)
+        mpp_buffer_inc_ref(p->colmv_buf);
+
     return frame;
 }
 
@@ -283,12 +313,15 @@ MPP_RET mpp_frame_copy(MppFrame dst, MppFrame src)
     if (p->meta)
         mpp_meta_put(p->meta);
 
+    colmv_buf_put(p);
     hdr_meta_ref_put(p);
 
     memcpy(dst, src, sizeof(MppFrameImpl));
     p = (MppFrameImpl *)src;
     if (p->meta)
         mpp_meta_inc_ref(p->meta);
+    if (p->colmv_buf)
+        mpp_buffer_inc_ref(p->colmv_buf);
 
     /* share the refcounted hdr meta instead of duplicating it */
     p = (MppFrameImpl *)dst;

--- a/mpp/base/mpp_meta.c
+++ b/mpp/base/mpp_meta.c
@@ -166,6 +166,11 @@ static inline RK_U64 META_KEY_TO_U64(RK_U32 key, RK_U32 type)
     ENTRY(KEY_ENC_FRAME_QP,         TYPE_VAL_32) \
     ENTRY(KEY_ENC_BASE_LAYER_PID,   TYPE_VAL_32) \
     \
+    /* raw decoder collocated motion-vector buffer */ \
+    ENTRY(KEY_DEC_COLMV,             TYPE_SPTR) \
+    ENTRY(KEY_DEC_COLMV_FMT,         TYPE_VAL_32) \
+    ENTRY(KEY_DEC_COLMV_SIZE,        TYPE_VAL_32) \
+    \
     ENTRY(KEY_DEC_TBN_EN,           TYPE_VAL_32) \
     ENTRY(KEY_DEC_TBN_Y_OFFSET,     TYPE_VAL_32) \
     ENTRY(KEY_DEC_TBN_UV_OFFSET,    TYPE_VAL_32)

--- a/mpp/hal/rkdec/h264d/hal_h264d_vdpu34x.c
+++ b/mpp/hal/rkdec/h264d/hal_h264d_vdpu34x.c
@@ -27,6 +27,7 @@
 #include "mpp_bitput.h"
 
 #include "mpp_device.h"
+#include "mpp_frame_impl.h"
 
 #include "hal_h264d_global.h"
 #include "hal_h264d_vdpu34x.h"
@@ -754,6 +755,30 @@ MPP_RET vdpu34x_h264d_gen_regs(void *hal, HalTaskInfo *task)
 
     if (vdpu34x_h264d_setup_colmv_buf(hal, width, height))
         goto __RETURN;
+
+    if (cfg->cfg->base.enable_colmv &&
+        mpp_get_soc_type() == ROCKCHIP_SOC_RK3588 &&
+        task->dec.output >= 0) {
+        RK_U32 compress = p_hal->pp->frame_mbs_only_flag ? 1 : 0;
+        RK_U32 valid_size = vdpu34x_get_colmv_size(width, height,
+                                                    16, 16, 4,
+                                                    compress);
+        MppFrame frame = NULL;
+
+        if (!p_hal->pp->frame_mbs_only_flag)
+            valid_size *= 2;
+
+        mpp_buf_slot_get_prop(cfg->frame_slots, task->dec.output,
+                              SLOT_FRAME_PTR, &frame);
+        if (frame) {
+            MppMeta meta = mpp_frame_get_meta(frame);
+
+            if (!meta || mpp_meta_set_s32(meta, KEY_DEC_COLMV_SIZE,
+                                         (RK_S32)valid_size))
+                mpp_err_f("failed to set H264 COLMV valid size\n");
+        }
+    }
+
     prepare_spspps(p_hal, (RK_U64 *)ctx->spspps, VDPU34X_SPSPPS_UNIT_SIZE / 8);
     prepare_framerps(p_hal, (RK_U64 *)ctx->rps, VDPU34X_RPS_SIZE / 8);
     prepare_scanlist(p_hal, ctx->sclst, VDPU34X_SCALING_LIST_SIZE);
@@ -900,6 +925,59 @@ __RETURN:
     return ret = MPP_OK;
 }
 
+static void vdpu34x_h264d_export_colmv(H264dHalCtx_t *p_hal,
+                                       HalTaskInfo *task,
+                                       Vdpu34xRegSet *regs,
+                                       RK_U32 valid)
+{
+    MppHalCfg *cfg = p_hal->cfg;
+    MppFrame frame = NULL;
+    MppMeta meta = NULL;
+    MppBuffer colmv = NULL;
+    MPP_RET meta_ret = MPP_OK;
+    RK_S32 fmt = MPP_DEC_COLMV_FMT_NONE;
+
+    if (mpp_get_soc_type() != ROCKCHIP_SOC_RK3588 ||
+        task->dec.output < 0)
+        return;
+
+    mpp_buf_slot_get_prop(cfg->frame_slots, task->dec.output,
+                          SLOT_FRAME_PTR, &frame);
+    if (!frame)
+        return;
+
+    if (valid && p_hal->cmv_bufs) {
+        HalBuf *mv_buf = hal_bufs_get_buf(p_hal->cmv_bufs,
+                                          task->dec.output);
+
+        if (mv_buf)
+            colmv = mv_buf->buf[0];
+        if (!colmv)
+            valid = 0;
+    }
+
+    if (!valid)
+        mpp_frame_set_colmv_buffer(frame, NULL);
+
+    meta = mpp_frame_get_meta(frame);
+    if (!meta)
+        return;
+
+    if (valid) {
+        mpp_frame_set_colmv_buffer(frame, colmv);
+        fmt = regs->comm_gen.reg012.colmv_compress_en ?
+              MPP_DEC_COLMV_FMT_VDPU34X_H264_COMPRESSED :
+              MPP_DEC_COLMV_FMT_VDPU34X_H264_UNCOMPRESSED;
+    }
+
+    meta_ret |= mpp_meta_set_buffer(meta, KEY_DEC_COLMV, colmv);
+    meta_ret |= mpp_meta_set_s32(meta, KEY_DEC_COLMV_FMT, fmt);
+    if (!valid)
+        meta_ret |= mpp_meta_set_s32(meta, KEY_DEC_COLMV_SIZE, 0);
+    if (meta_ret)
+        mpp_err_f("failed to export decoder COLMV metadata\n");
+}
+
 MPP_RET vdpu34x_h264d_wait(void *hal, HalTaskInfo *task)
 {
     MPP_RET ret = MPP_ERR_UNKNOW;
@@ -921,6 +999,23 @@ MPP_RET vdpu34x_h264d_wait(void *hal, HalTaskInfo *task)
         mpp_err_f("poll cmd failed %d\n", ret);
 
 __SKIP_HARD:
+    if (p_hal->cfg->cfg->base.enable_colmv) {
+        RK_U32 colmv_valid =
+            !task->dec.flags.parse_err &&
+            !(task->dec.flags.ref_err &&
+              !p_hal->cfg->cfg->base.disable_error) &&
+            ret == MPP_OK &&
+            !p_regs->irq_status.reg224.dec_error_sta &&
+            p_regs->irq_status.reg224.dec_rdy_sta &&
+            !p_regs->irq_status.reg224.buf_empty_sta &&
+            !p_regs->irq_status.reg226.strmd_error_status &&
+            !p_regs->irq_status.reg227.colmv_error_ref_picidx &&
+            !p_regs->irq_status.reg225.strmd_detect_error_flag;
+
+        vdpu34x_h264d_export_colmv(p_hal, task, p_regs,
+                                   colmv_valid);
+    }
+
     if (p_hal->cfg->dec_cb) {
         DecCbHalDone param;
 

--- a/mpp/hal/rkdec/h265d/hal_h265d_vdpu34x.c
+++ b/mpp/hal/rkdec/h265d/hal_h265d_vdpu34x.c
@@ -23,6 +23,7 @@
 #include "mpp_mem.h"
 #include "mpp_bitread.h"
 #include "mpp_bitput.h"
+#include "mpp_frame_impl.h"
 
 #include "hal_hw_id.h"
 #include "h265d_syntax.h"
@@ -931,6 +932,22 @@ static MPP_RET hal_h265d_vdpu34x_gen_regs(void *hal,  HalTaskInfo *syn)
         hal_bufs_setup(reg_ctx->cmv_bufs, reg_ctx->mv_count, 1, &size);
     }
 
+    if (cfg->cfg->base.enable_colmv &&
+        mpp_get_soc_type() == ROCKCHIP_SOC_RK3588 &&
+        syn->dec.output >= 0) {
+        MppFrame frame = NULL;
+
+        mpp_buf_slot_get_prop(cfg->frame_slots, syn->dec.output,
+                              SLOT_FRAME_PTR, &frame);
+        if (frame) {
+            MppMeta meta = mpp_frame_get_meta(frame);
+
+            if (!meta || mpp_meta_set_s32(meta, KEY_DEC_COLMV_SIZE,
+                                         (RK_S32)mv_size))
+                mpp_err_f("failed to set H265 COLMV valid size\n");
+        }
+    }
+
     {
         MppFrame mframe = NULL;
         RK_U32 ver_virstride;
@@ -1265,6 +1282,56 @@ static MPP_RET hal_h265d_vdpu34x_start(void *hal, HalTaskInfo *task)
 }
 
 
+static void hal_h265d_vdpu34x_export_colmv(HalH265dCtx *reg_ctx,
+                                           HalTaskInfo *task,
+                                           RK_U32 valid)
+{
+    MppHalCfg *cfg = reg_ctx->cfg;
+    MppFrame frame = NULL;
+    MppMeta meta = NULL;
+    MppBuffer colmv = NULL;
+    MPP_RET meta_ret = MPP_OK;
+    RK_S32 fmt = MPP_DEC_COLMV_FMT_NONE;
+
+    if (mpp_get_soc_type() != ROCKCHIP_SOC_RK3588 ||
+        task->dec.output < 0)
+        return;
+
+    mpp_buf_slot_get_prop(cfg->frame_slots, task->dec.output,
+                          SLOT_FRAME_PTR, &frame);
+    if (!frame)
+        return;
+
+    if (valid && reg_ctx->cmv_bufs) {
+        HalBuf *mv_buf = hal_bufs_get_buf(reg_ctx->cmv_bufs,
+                                          task->dec.output);
+
+        if (mv_buf)
+            colmv = mv_buf->buf[0];
+        if (!colmv)
+            valid = 0;
+    }
+
+    if (!valid)
+        mpp_frame_set_colmv_buffer(frame, NULL);
+
+    meta = mpp_frame_get_meta(frame);
+    if (!meta)
+        return;
+
+    if (valid) {
+        mpp_frame_set_colmv_buffer(frame, colmv);
+        fmt = MPP_DEC_COLMV_FMT_VDPU34X_H265_COMPRESSED;
+    }
+
+    meta_ret |= mpp_meta_set_buffer(meta, KEY_DEC_COLMV, colmv);
+    meta_ret |= mpp_meta_set_s32(meta, KEY_DEC_COLMV_FMT, fmt);
+    if (!valid)
+        meta_ret |= mpp_meta_set_s32(meta, KEY_DEC_COLMV_SIZE, 0);
+    if (meta_ret)
+        mpp_err_f("failed to export decoder COLMV metadata\n");
+}
+
 static MPP_RET hal_h265d_vdpu34x_wait(void *hal, HalTaskInfo *task)
 {
     MPP_RET ret = MPP_OK;
@@ -1294,6 +1361,20 @@ static MPP_RET hal_h265d_vdpu34x_wait(void *hal, HalTaskInfo *task)
         mpp_err_f("poll cmd failed %d\n", ret);
 
 ERR_PROC:
+    if (cfg->cfg->base.enable_colmv) {
+        RK_U32 colmv_valid =
+            ret == MPP_OK &&
+            !task->dec.flags.parse_err &&
+            !task->dec.flags.ref_err &&
+            !hw_regs->irq_status.reg224.dec_error_sta &&
+            !hw_regs->irq_status.reg224.buf_empty_sta &&
+            !hw_regs->irq_status.reg224.dec_bus_sta &&
+            hw_regs->irq_status.reg224.dec_rdy_sta;
+
+        hal_h265d_vdpu34x_export_colmv(reg_ctx, task,
+                                       colmv_valid);
+    }
+
     if (task->dec.flags.parse_err ||
         task->dec.flags.ref_err ||
         hw_regs->irq_status.reg224.dec_error_sta ||

--- a/mpp/inc/mpp_dec_cfg.h
+++ b/mpp/inc/mpp_dec_cfg.h
@@ -53,6 +53,7 @@ typedef struct MppDecBaseCfg_t {
     RK_U32              enable_vproc;   /* MppVprocMode */
     RK_U32              enable_fast_play;
     RK_U32              enable_hdr_meta;
+    RK_U32              enable_colmv;      /* export raw decoder COLMV metadata */
     RK_U32              enable_thumbnail;
     RK_U32              enable_mvc;
     RK_U32              disable_dpb_chk;

--- a/test/mpi_dec_test.c
+++ b/test/mpi_dec_test.c
@@ -46,7 +46,92 @@ typedef struct {
     RK_S64          delay;
     FILE            *fp_verify;
     FrmCrc          checkcrc;
+
+    /* Optional raw decoder COLMV validation. */
+    RK_U32          colmv_enable;
+    RK_U32          colmv_frames;
+    RK_U32          colmv_nonzero_frames;
+    MPP_RET         colmv_ret;
 } MpiDecLoopData;
+
+static MPP_RET dec_validate_colmv(MpiDecLoopData *data, MppFrame frame)
+{
+    MppMeta meta = NULL;
+    MppBuffer colmv = NULL;
+    RK_S32 fmt = MPP_DEC_COLMV_FMT_NONE;
+    RK_U8 *ptr = NULL;
+    size_t capacity = 0;
+    size_t size = 0;
+    RK_S32 valid_size = 0;
+    size_t i;
+    RK_U32 nonzero = 0;
+    RK_U32 hash = 2166136261U;
+    MPP_RET ret;
+
+    if (!data->colmv_enable || !mpp_frame_has_meta(frame))
+        return MPP_OK;
+
+    meta = mpp_frame_get_meta(frame);
+    if (!meta)
+        return MPP_NOK;
+
+    ret = mpp_meta_get_buffer(meta, KEY_DEC_COLMV, &colmv);
+    if (ret || !colmv)
+        return MPP_OK;
+
+    ret = mpp_meta_get_s32(meta, KEY_DEC_COLMV_FMT, &fmt);
+    if (ret || fmt <= MPP_DEC_COLMV_FMT_NONE ||
+        fmt >= MPP_DEC_COLMV_FMT_BUTT) {
+        mpp_err_f("invalid COLMV format %d ret %d\n", fmt, ret);
+        return MPP_NOK;
+    }
+
+    ret = mpp_meta_get_s32(meta, KEY_DEC_COLMV_SIZE, &valid_size);
+    if (ret || valid_size <= 0) {
+        mpp_err_f("invalid COLMV valid size %d ret %d\n",
+                  valid_size, ret);
+        return MPP_NOK;
+    }
+
+    capacity = mpp_buffer_get_size(colmv);
+    size = (size_t)valid_size;
+    ptr = (RK_U8 *)mpp_buffer_get_ptr(colmv);
+    if (!capacity || !ptr || size > capacity) {
+        mpp_err_f("invalid COLMV buffer ptr %p valid %zu capacity %zu\n",
+                  ptr, size, capacity);
+        return MPP_NOK;
+    }
+
+    ret = mpp_buffer_sync_ro_begin(colmv);
+    if (ret) {
+        mpp_err_f("COLMV sync begin failed ret %d\n", ret);
+        return ret;
+    }
+
+    for (i = 0; i < size; i++) {
+        RK_U8 val = ptr[i];
+
+        if (val)
+            nonzero++;
+        hash ^= val;
+        hash *= 16777619U;
+    }
+
+    ret = mpp_buffer_sync_ro_end(colmv);
+    if (ret) {
+        mpp_err_f("COLMV sync end failed ret %d\n", ret);
+        return ret;
+    }
+
+    data->colmv_frames++;
+    if (nonzero)
+        data->colmv_nonzero_frames++;
+
+    mpp_log("COLMV frame %d fmt %d size %zu nonzero %u hash %08x\n",
+            data->frame_count, fmt, size, nonzero, hash);
+
+    return MPP_OK;
+}
 
 static MPP_RET dec_simple(MpiDecLoopData *data)
 {
@@ -185,6 +270,14 @@ static MPP_RET dec_simple(MpiDecLoopData *data)
 
                     if (!data->first_frm)
                         data->first_frm = mpp_time();
+
+                    ret = dec_validate_colmv(data, frame);
+                    if (ret) {
+                        mpp_err_f("COLMV validation failed ret %d\n", ret);
+                        data->colmv_ret = ret;
+                        mpp_frame_deinit(&frame);
+                        return ret;
+                    }
 
                     log_len += snprintf(log_buf + log_len, log_size - log_len,
                                         "decode get frame %d", data->frame_count);
@@ -426,6 +519,7 @@ int dec_decode(MpiDecTestCmd *cmd)
     // config for runtime mode
     MppDecCfg cfg       = NULL;
     RK_U32 need_split   = 1;
+    RK_U32 enable_colmv = 0;
 
     // resources
     MppBuffer frm_buf   = NULL;
@@ -516,6 +610,7 @@ int dec_decode(MpiDecTestCmd *cmd)
     }
 
     mpp_dec_cfg_init(&cfg);
+    mpp_env_get_u32("mpi_dec_colmv", &enable_colmv, 0);
 
     /* get default config from decoder context */
     ret = mpi->control(ctx, MPP_DEC_GET_CFG, cfg);
@@ -534,6 +629,15 @@ int dec_decode(MpiDecTestCmd *cmd)
         goto MPP_TEST_OUT;
     }
 
+    if (enable_colmv) {
+        ret = mpp_dec_cfg_set_u32(cfg, "base:enable_colmv", 1);
+        if (ret) {
+            mpp_err("%p failed to enable COLMV ret %d\n", ctx, ret);
+            goto MPP_TEST_OUT;
+        }
+        mpp_log("%p decoder raw COLMV export enabled\n", ctx);
+    }
+
     ret = mpi->control(ctx, MPP_DEC_SET_CFG, cfg);
     if (ret) {
         mpp_err("%p failed to set cfg %p ret %d\n", ctx, cfg, ret);
@@ -549,6 +653,7 @@ int dec_decode(MpiDecTestCmd *cmd)
     data.frame_count    = 0;
     data.frame_num      = cmd->frame_num;
     data.quiet          = cmd->quiet;
+    data.colmv_enable   = enable_colmv;
 
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
 
@@ -569,6 +674,24 @@ int dec_decode(MpiDecTestCmd *cmd)
     }
 
     pthread_join(thd, NULL);
+
+    if (enable_colmv) {
+        if (data.colmv_ret) {
+            mpp_err("COLMV validation thread failed ret %d\n",
+                    data.colmv_ret);
+            ret = data.colmv_ret;
+            goto MPP_TEST_OUT;
+        }
+
+        mpp_log("COLMV summary frames %u nonzero_frames %u\n",
+                data.colmv_frames, data.colmv_nonzero_frames);
+
+        if (!data.colmv_frames) {
+            mpp_err("COLMV export enabled but no COLMV buffer was received\n");
+            ret = MPP_NOK;
+            goto MPP_TEST_OUT;
+        }
+    }
 
     cmd->max_usage = data.max_usage;
 


### PR DESCRIPTION
## Summary

Add opt-in raw decoder COLMV export for RK3588 H.264/H.265 decode on the VDPU34x path.

The decoder config adds:

- `base:enable_colmv` — disabled by default
- `KEY_DEC_COLMV` — raw hardware COLMV `MppBuffer`
- `KEY_DEC_COLMV_FMT` — hardware layout identifier
- `KEY_DEC_COLMV_SIZE` — valid payload size for the current frame

The exported buffer is retained for the lifetime of the output `MppFrame`.

## Semantics

This exposes the decoder's existing hardware-generated COLMV buffer. It is raw, hardware-specific data; this is not a portable or already-decoded motion-vector API.

When `base:enable_colmv` is disabled, the HAL export path is skipped and performs no COLMV metadata access, buffer copy, or cache synchronization.

When enabled:

- no COLMV payload copy is performed
- no implicit CPU cache synchronization is performed
- CPU consumers should use `mpp_buffer_sync_ro_begin()` / `mpp_buffer_sync_ro_end()` around reads
- DMA consumers can use the exported buffer without a CPU readback
- the buffer remains owned by the output frame; consumers that need it beyond the frame lifetime must retain their own reference

Initial format identifiers cover:

- VDPU34x H.264 compressed COLMV
- VDPU34x H.264 uncompressed COLMV
- VDPU34x H.265 compressed COLMV

The export is currently gated to RK3588.

`mpi_dec_test` can enable and inspect the path with `mpi_dec_colmv=1`.

## Validation

Validated on OrangePi 5 / RK3588 using the exact Git tree:

`14cd9c6c64ee07ec100e2020fd829d0923f03b63`

with commit:

`cbf19a9e70a41cda2e417318c14efa6703d1002e`

Validation included:

- full Release build with `WARNINGS_AS_ERRORS=ON`
- `mpp_info_test`
- `mpp_dec_cfg_test`
- `mpp_sys_cfg_test`
- H.264 decode with COLMV disabled: 90 frames
- H.264 with COLMV enabled: 90/90 non-zero COLMV frames, 89 unique payload hashes
- H.265 decode with COLMV disabled: 90 frames
- H.265 with COLMV enabled: 90/90 non-zero COLMV frames, 90 unique payload hashes
- no new matching decoder/IOMMU kernel faults

The enabled validation path intentionally performs CPU cache sync and hashes the COLMV bytes to verify the hardware output; that diagnostic readback is not part of the normal disabled path.